### PR TITLE
AGPL-3.0

### DIFF
--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -22,7 +22,7 @@
     "sources": "https://github.com/MangZai-120/shape-shifter-curse-addon",
     "issues": "https://github.com/MangZai-120/shape-shifter-curse-addon/issues"
   },
-  "license": "MIT",
+  "license": "AGPL-3.0",
   "icon": "assets/ssc_addon/icon.png",
   "environment": "*",
   "entrypoints": {


### PR DESCRIPTION
原因：发现游戏内显示的license和实际仓库的license不同（图片在群里面）